### PR TITLE
[Config]: Add track tags

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,5 +27,14 @@
   },
   "concepts": [],
   "key_features": [],
-  "tags": []
+  "tags": [
+    "paradigm/object_oriented",
+    "typing/dynamic",
+    "execution_mode/interpreted",
+    "platform/windows",
+    "platform/mac",
+    "platform/linux",
+    "platform/android",
+    "used_for/games"
+  ]
 }


### PR DESCRIPTION
@pfertyk,`./bin/configlet lint` warns about the tags array being empty in the track's config. Here are a handful of tags to get the ball started. More information is at https://exercism.org/docs/building/tracks/config-json#h-tag so let me know if you want to switch out any tags. Merging this in will make configlet move on to complaining about hello-world not being present so merging in #3 when it's ready should take care of that.