### PR TITLE
[Docs]: Add track blurb

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "representer": false,
     "analyzer": false
   },
-  "blurb": "TODO: add blurb",
+  "blurb": "GDScript is a versatile scripting language seamlessly integrated into the cross-platform open-source Godot 2D/3D game engine.",
   "version": 3,
   "online_editor": {
     "indent_style": "space",


### PR DESCRIPTION
Per https://exercism.org/docs/building/tracks/new/prepare-for-launch, we need a short description of the language. This shows up on the About page so it'll be one of the first things prospective students see. The final blurb should be less than 400 characters, and my first pass is only 125 characters so we can make this a bit more thorough. :)