### PR TITLE
Pin GDScript Toolkit to v4.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup gdtoolkit
-        uses: Scony/godot-gdscript-toolkit@09af1747fd66629af601b1f14d1ac24203358686
+        uses: Scony/godot-gdscript-toolkit@af9a6e36935fe7319aa559ca068ef8f2392d99c3
 
       - name: Lint
         run: gdlint exercises

--- a/bin/verify-exercises
+++ b/bin/verify-exercises
@@ -18,9 +18,9 @@ run_test() {
     # Check status
     test_status="$(jq -r '.status' $temp_dir/results.json)"
     if [ "$test_status" != "pass" ]; then
-    	echo "Tests for $slug have failed:"
-    	cat $temp_dir/results.json
-    	exit 1
+        echo "Tests for $slug have failed:"
+        cat $temp_dir/results.json
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This is the closest we can get to the Godot Engine's version used by our test runner: v4.1.1 .