### PR TITLE
Fix indentation in exercise files

### DIFF
--- a/exercises/practice/leap/.meta/example.gd
+++ b/exercises/practice/leap/.meta/example.gd
@@ -1,2 +1,2 @@
 func leap(year):
-    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+	return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/exercises/practice/leap/leap.gd
+++ b/exercises/practice/leap/leap.gd
@@ -1,2 +1,2 @@
 func leap(year):
-    pass
+	pass

--- a/exercises/practice/leap/leap_test.gd
+++ b/exercises/practice/leap/leap_test.gd
@@ -1,26 +1,34 @@
 func test_year_not_divisible_by_4(solution_script):
 	return [false, solution_script.leap(2015)]
 
+
 func test_year_divisible_by_2_not_4(solution_script):
-     return [false, solution_script.leap(1970)]
+	return [false, solution_script.leap(1970)]
+
 
 func test_year_divisible_by_4_not_100(solution_script):
-     return [true, solution_script.leap(1996)]
+	return [true, solution_script.leap(1996)]
+
 
 func test_year_divisible_by_4_and_5(solution_script):
-     return [true, solution_script.leap(1960)]
+	return [true, solution_script.leap(1960)]
+
 
 func test_year_divisible_by_100_not_400(solution_script):
-     return [false, solution_script.leap(2100)]
+	return [false, solution_script.leap(2100)]
+
 
 func test_year_divisible_by_100_not_3(solution_script):
-     return [false, solution_script.leap(1900)]
+	return [false, solution_script.leap(1900)]
+
 
 func test_year_divisible_by_400(solution_script):
-     return [true, solution_script.leap(2000)]
+	return [true, solution_script.leap(2000)]
+
 
 func test_year_divisible_by_400_not_125(solution_script):
-     return [true, solution_script.leap(2400)]
+	return [true, solution_script.leap(2400)]
+
 
 func test_year_divisible_by_200_not_400(solution_script):
-     return [false, solution_script.leap(1800)]
+	return [false, solution_script.leap(1800)]

--- a/exercises/practice/resistor-color-duo/.meta/example.gd
+++ b/exercises/practice/resistor-color-duo/.meta/example.gd
@@ -1,16 +1,18 @@
-const COLORS = ["black",
-                "brown",
-                "red",
-                "orange",
-                "yellow",
-                "green",
-                "blue",
-                "violet",
-                "grey",
-                "white"]
+const COLORS = [
+	"black",
+	"brown",
+	"red",
+	"orange",
+	"yellow",
+	"green",
+	"blue",
+	"violet",
+	"grey",
+	"white"
+]
 
 
 func color_code(colors):
-    var tens = colors[0]
-    var ones = colors[1]
-    return COLORS.find(tens) * 10 + COLORS.find(ones)
+	var tens = colors[0]
+	var ones = colors[1]
+	return COLORS.find(tens) * 10 + COLORS.find(ones)

--- a/exercises/practice/resistor-color-duo/resistor_color_duo.gd
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo.gd
@@ -1,2 +1,2 @@
 func color_code(colors):
-    pass
+	pass

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.gd
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.gd
@@ -1,40 +1,40 @@
 func test_brown_and_black(solution_script):
-    var colors = ["brown", "black"]
-    var expected = 10
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["brown", "black"]
+	var expected = 10
+	return [expected, solution_script.color_code(colors)]
 
 
 func test_blue_and_grey(solution_script):
-    var colors = ["blue", "grey"]
-    var expected = 68
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["blue", "grey"]
+	var expected = 68
+	return [expected, solution_script.color_code(colors)]
 
 
 func test_yellow_and_violet(solution_script):
-    var colors = ["yellow", "violet"]
-    var expected = 47
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["yellow", "violet"]
+	var expected = 47
+	return [expected, solution_script.color_code(colors)]
 
 
 func test_white_and_red(solution_script):
-    var colors = ["white", "red"]
-    var expected = 92
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["white", "red"]
+	var expected = 92
+	return [expected, solution_script.color_code(colors)]
 
 
 func test_orange_and_orange(solution_script):
-    var colors = ["orange", "orange"]
-    var expected = 33
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["orange", "orange"]
+	var expected = 33
+	return [expected, solution_script.color_code(colors)]
 
 
 func test_ignore_additional_colors(solution_script):
-    var colors = ["green", "brown", "orange"]
-    var expected = 51
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["green", "brown", "orange"]
+	var expected = 51
+	return [expected, solution_script.color_code(colors)]
 
 
 func test_black_and_brown_one_digit(solution_script):
-    var colors = ["black", "brown"]
-    var expected = 1
-    return [expected, solution_script.color_code(colors)]
+	var colors = ["black", "brown"]
+	var expected = 1
+	return [expected, solution_script.color_code(colors)]

--- a/exercises/practice/resistor-color/.meta/example.gd
+++ b/exercises/practice/resistor-color/.meta/example.gd
@@ -1,18 +1,20 @@
-const COLORS = ["black",
-                "brown",
-                "red",
-                "orange",
-                "yellow",
-                "green",
-                "blue",
-                "violet",
-                "grey",
-                "white"]
+const COLORS = [
+	"black",
+	"brown",
+	"red",
+	"orange",
+	"yellow",
+	"green",
+	"blue",
+	"violet",
+	"grey",
+	"white"
+]
 
 
 func color_code(color):
-    return COLORS.find(color)
+	return COLORS.find(color)
 
 
 func colors():
-    return COLORS
+	return COLORS

--- a/exercises/practice/resistor-color/resistor_color.gd
+++ b/exercises/practice/resistor-color/resistor_color.gd
@@ -1,6 +1,6 @@
 func color_code(color):
-    pass
+	pass
 
 
 func colors():
-    pass
+	pass

--- a/exercises/practice/resistor-color/resistor_color_test.gd
+++ b/exercises/practice/resistor-color/resistor_color_test.gd
@@ -3,24 +3,24 @@ func test_color_codes_black(solution_script):
 
 
 func test_color_codes_white(solution_script):
-    return [9, solution_script.color_code("white")]
+	return [9, solution_script.color_code("white")]
 
 
 func test_color_codes_orange(solution_script):
-    return [3, solution_script.color_code("orange")]
+	return [3, solution_script.color_code("orange")]
 
 
 func test_colors(solution_script):
-    return [
-        ["black",
-         "brown",
-         "red",
-         "orange",
-         "yellow",
-         "green",
-         "blue",
-         "violet",
-         "grey",
-         "white"],
-        solution_script.colors()
-    ]
+	var colors = [
+		"black",
+		"brown",
+		"red",
+		"orange",
+		"yellow",
+		"green",
+		"blue",
+		"violet",
+		"grey",
+		"white"
+	]
+	return [colors, solution_script.colors()]


### PR DESCRIPTION
Mixed indentation causes some test files to not be executed correctly, and in results we're skipping tests for some exercises. Unfortunately, current CI doesn't detect these types of issues. but perhaps later we can upgrade the test runner to handle this.