### PR TITLE
Add test runner setup instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Exercism exercises in GDScript.
 
 ## Testing
 
+To set up for testing, clone https://github.com/exercism/gdscript-test-runner and move its contents to `/opt/test-runner`.
+
 To test the exercises, run `./bin/verify-exercises`.
 This command will iterate over all exercises and check to see if their exemplar/example implementation passes all the tests.
 


### PR DESCRIPTION
I'm not sure if this is the standard for Exercism or if it would be better to have `bin/verify-exercises` point somewhere else — maybe include the test runner as a Git submodule?

Anyway, the added instruction at least helps get started for the moment.