### PR TITLE
Update `resistor-color-trio` example to pass on Godot Engine v4.4.1

### DIFF
--- a/exercises/practice/resistor-color-trio/.meta/example.gd
+++ b/exercises/practice/resistor-color-trio/.meta/example.gd
@@ -13,6 +13,9 @@ func color_code(colors):
 
 	for key in units.keys():
 		if total >= key:
-			return str(total / key) + " " + units[key]
+			return format_number(total / key) + " " + units[key]
 
-	return str(total) + " ohms"
+	return format_number(total) + " ohms"
+
+func format_number(n):
+	return str(int(n)) if n == int(n) else str(n)


### PR DESCRIPTION
.stable.official.49a5bc7b6 (cf. https://github.com/exercism/gdscript/issues/38)