### PR TITLE
Update `resistor-color-expert` example to pass on Godot Engine v4.4.1…

### DIFF
--- a/exercises/practice/resistor-color-expert/.meta/example.gd
+++ b/exercises/practice/resistor-color-expert/.meta/example.gd
@@ -30,5 +30,8 @@ func color_code(colors):
 	var tolerance  = tolerances[colors[-1]] #work
 	for key in units.keys():
 		if total >= key:
-			return "%s %s ±%s%%" % [(total / key), units[key], tolerance]
-	return "%s ohms ±%s%%" % [total, tolerance]
+			return "%s %s ±%s%%" % [format_number(total / key), units[key], tolerance]
+	return "%s ohms ±%s%%" % [format_number(total), tolerance]
+
+func format_number(n):
+	return str(int(n)) if n == int(n) else str(n)


### PR DESCRIPTION
….stable.official.49a5bc7b6 (cf. https://github.com/exercism/gdscript/issues/38)