### PR TITLE
Add GDScript reference to resources

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,5 +1,6 @@
 # Resources
 * [Official Godot Homepage](https://godotengine.org/)
+* [Official GDScript Reference](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/index.html)
 * [Official Godot Documentation](https://docs.godotengine.org/en/stable/)
 * [Official Godot Q&A Platform](https://ask.godotengine.org/)
 * [Official Godot Discord](https://discord.com/invite/4JBkykG)


### PR DESCRIPTION
It's more to the point of this track than the main docs.  (Yet, it's slightly buried within them under Manual → Scripting.  I've often gone to Manual then figured I misremembered, since Scripting is somewhat unlike most of the sibling items above it.)